### PR TITLE
Print Screen - output to terminal

### DIFF
--- a/lib/pws.rb
+++ b/lib/pws.rb
@@ -59,6 +59,23 @@ class PWS
   end
   aliases_for :show, :ls, :list, :status
   
+  # Add multiple passwords at a time
+  def multiadd()
+    begin
+      while true
+        key = ask_for_input(false, %[please enter a key to add (or empty to quit)], :yellow)
+        if key.empty?
+          pa %[Exiting...]
+          break
+        end
+
+        password = ask_for_password(%[please enter a password for #{key}], :yellow)
+
+        add(key, password)
+      end
+    end
+  end
+
   # Add a password entry, params: name, password (optional, opens prompt if not given)
   def add(key, password = nil)
     if @data[key]
@@ -273,13 +290,17 @@ class PWS
   
   # Prompts the user for a password
   def ask_for_password(prompt = 'new password', *colors)
+    ask_for_input(true, prompt, *colors)
+  end
+
+  def ask_for_input(hide_output, prompt, *colors)
     print Paint["#{prompt}:".capitalize, *colors] + " "
-    system 'stty -echo' if $stdin.tty?     # no more terminal output
-    password = ($stdin.gets||'').chop      # gets without $stdin would mistakenly read_safe from ARGV
-    system 'stty echo'  if $stdin.tty?     # restore terminal output
-    puts "\e[999D\e[K\e[1A" if $stdin.tty? # re-use prompt line in terminal
+    system 'stty -echo' if $stdin.tty? && hide_output # no more terminal output
+    input = ($stdin.gets||'').chop                    # gets without $stdin would mistakenly read_safe from ARGV
+    system 'stty echo'  if $stdin.tty? && hide_output # restore terminal output
+    puts "\e[999D\e[K\e[1A" if $stdin.tty?            # re-use prompt line in terminal
     
-    password
+    input
   end
   
   # Generate a random password, maybe put in its own class sometime

--- a/lib/pws.rb
+++ b/lib/pws.rb
@@ -59,6 +59,32 @@ class PWS
   end
   aliases_for :show, :ls, :list, :status
   
+  # print a password entry to the screen
+  def print_screen(key, seconds = @options[:seconds])
+    if real_key = @abbrevs[key]
+      password = @data[real_key][:password]
+      if seconds && seconds.to_i > 0
+        #pa %[The password for #{real_key} will be displayed for #{seconds.to_i} seconds: #{password}], :green
+        print Paint[%[The password for #{real_key} will be displayed for #{seconds.to_i} seconds: #{password}], :green]
+        begin
+          sleep seconds.to_i
+        rescue Interrupt
+          puts "\e[999D\e[K\e[1A" if $stdin.tty? # clear the pw from the screen
+          raise
+        end
+        puts "\e[999D\e[K\e[1A" if $stdin.tty? # clear the pw from the screen
+        return true
+      else
+        pa %[The password for #{real_key} is: #{password}], :green
+        return true
+      end
+    else
+      pa %[No password found for #{key}!], :red
+      return false
+    end
+  end
+  aliases_for :print_screen, :ps
+
   # Add multiple passwords at a time
   def multiadd()
     begin


### PR DESCRIPTION
I run my pw manager on a colo'd box with no X.  I understand the threat model and I want to output my passwords to the terminals anyways.  I added the "print_screen" function (alias "ps") to print out a password.  After the given number of seconds, if an interactive terminal is detected, the password is overwritten using shell escapes (the same way a password line is reused in the ask_for_password method earlier).

Again, missing tests - if you want to accept this, let me know, and I'll write some tests and a cleaner diff for you.

Thanks!
-Carl
