### PR TITLE
added username to password entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
-pws [![[travis]](https://travis-ci.org/janlelis/pws.png)](https://travis-ci.org/janlelis/pws)
+pws
 ===
-pws is a command-line password safe/manager written in Ruby using [aes-256-cbc](http://en.wikipedia.org/wiki/Advanced_Encryption_Standard) and [pbkdf2](http://en.wikipedia.org/wiki/PBKDF2).
+This is a fork of [*pws* by Jan Lelis](https://github.com/janlelis/pws), a command-line password safe/manager written in Ruby using [aes-256-cbc](http://en.wikipedia.org/wiki/Advanced_Encryption_Standard) and [pbkdf2](http://en.wikipedia.org/wiki/PBKDF2).
 
+This version adds the option to store usernames along with passwords. Read below the instructions to update to this version if you have version 1.0 or 0.9 already installed.
 
 Usage
 ---
-[![Screenshot](http://rbjl.net/pws-example.png)](http://rbjl.net/60-pws-the-ruby-powered-command-line-password-manager)
 
+* Add new passwords with `$ pws add <key>`. You will be prompted for a username and password that will encrypted and stored in your home directory.
+* Retrieve your usernames and passwords with `$ pws get <key>`. The username will be displayed and the password will be copied to your clipboard.
+
+Type `pws help` for complete usage instructions.
 
 Setup
 ---
-You can install *pws* with: `$ gem install pws`
+
+To install *pws 1.1* with usernames support you need to clone this repository and create a local gem:
+
+* `$ gem build pws.gemspec`
+* `$ gem install pws-1.1.gem`
+
+You can install *pws 1.0* with: `$ gem install pws`
 
 Run `$ pws --help` for usage information.
 
@@ -23,9 +33,9 @@ Hints
 You should use a Ruby that was built with bindings to an openssl version >= 1.0 or pws will fall back to a Ruby-only version of the PBKDF2 function, which is much slower. If using openssl 1.0 is not possible for you, you can work around that issue by using the `--iterations` option with a value below 75\_000 (see help). If you have problems using openssl 1.0 with your Ruby, please look for a solution in [this issue](https://github.com/janlelis/pws/issues/7).
 
 
-### Updating from pws 0.9
-The 0.9 password files are not compatible with the 1.0 version of pws, however, you can convert your safe with:
-`$ pws resave --in 0.9 --out 1.0`
+### Updating to pws 1.1 with usernames
+Password files created with versions < 1.1 are not compatible with version 1.1. However, you can easily convery your safes with:
+`$ pws resave --in [0.9|1.0] --out 1.1`
 
 
 ### How to use a .pws file in the current working directory
@@ -48,3 +58,4 @@ Contributors
 J-\_-L
 ---
 © 2010-2013 Jan Lelis, MIT license
+© 2014 Aaron Ciaghi, MIT license (usernames addon)

--- a/lib/pws.rb
+++ b/lib/pws.rb
@@ -16,23 +16,23 @@ class PWS
 
   class NoAccess < StandardError; end
   class NoLegacyAccess < NoAccess; end
-  
+
   attr_reader :filename
-  
+
   # Creates a new password safe. Takes the path to the password file, by default: ~/.pws
-  # Second parameter allows namespaces that get appended to the file name (uses another safe) 
+  # Second parameter allows namespaces that get appended to the file name (uses another safe)
   # You can pass the master password as third parameter (not recommended)
   def initialize(options)
     collect_options(options)
     @filename = @options[:cwd] ? File.join(FileUtils.pwd, '.pws') : File.expand_path(@options[:filename])
     @filename << '-' << @options[:namespace] if @options[:namespace]
-    
+
     read_safe(options[:password])
   end
-  
+
   # Shows a password entry list
   def show(pattern = nil)
-    if @data.empty? 
+    if @data.empty?
       pa %[There aren't any passwords stored at #{@filename}, yet], :red
     else
       if pattern
@@ -40,7 +40,7 @@ class PWS
       else
         keys = @data.keys
       end
-      
+
       if keys.empty?
         pa %[No passwords found for pattern /#{pattern}/], :red
       else
@@ -49,7 +49,7 @@ class PWS
         puts keys.sort.map{ |key|
           "- #{
             Paint[key, :bold]
-          } #{ 
+          } #{
             Time.at(@data[key][:timestamp].to_i).strftime('%y-%m-%d') if @data[key][:timestamp].to_i != 0
           }\n"
         }.join
@@ -60,14 +60,15 @@ class PWS
     raise ArgumentError, %[Invalid regex given]
   end
   aliases_for :show, :ls, :list, :status
-  
-  # Add a password entry, params: name, password (optional, opens prompt if not given)
-  def add(key, password = nil)
+
+  # Add a password entry, params: name, username (optional), password (optional, opens prompt if not given)
+  def add(key, username = nil, password = nil)
     if @data[key]
       pa %[There is already a password stored for #{key}. You need to remove it before creating a new one!], :red
       return false
     else
       @data[key] = {}
+      @data[key][:username] = username || ask_for_username(%[please enter the username for #{key} (press blank to skip)], :yellow)
       @data[key][:password] = password || ask_for_password(%[please enter a password for #{key}], :yellow)
       if @data[key][:password].empty?
         raise ArgumentError, %[Cannot set an empty password!]
@@ -80,7 +81,7 @@ class PWS
     end
   end
   aliases_for :add, :set, :store, :create
-  
+
   # Updates a password entry, params: name, password (optional, opens prompt if not given)
   def update(key, password = nil)
     if !@data[key]
@@ -99,15 +100,22 @@ class PWS
     end
   end
   alias :'update-add' :update
-  
+
   # Gets the password entry and copies it to the clipboard. The second parameter is the time in seconds it stays there
   def get(key, seconds = @options[:seconds])
     if real_key = @abbrevs[key]
       password = @data[real_key][:password]
+
+      puts "--------------------------------"
+      pa "#{real_key}", :yellow, :bright
+      puts
+      puts "#{Paint['Username:',:bright]} #{@data[real_key][:username]}" if @data[real_key][:username]
+
       if seconds && seconds.to_i > 0
         original_clipboard_content = Clipboard.paste
         Clipboard.copy password
-        pa %[The password for #{real_key} is now available in your clipboard for #{seconds.to_i} second#{?s if seconds.to_i > 1}], :green
+        puts "#{Paint['Password:',:bright]} #{Paint['in your clipboard for ' + seconds.to_s + ' seconds',:green]}"
+        puts "--------------------------------"
         begin
           sleep seconds.to_i
         rescue Interrupt
@@ -118,27 +126,30 @@ class PWS
         return true
       else
         Clipboard.copy password
-        pa %[The password for #{real_key} has been copied to your clipboard], :green
+        puts "#{Paint['Password:',:bright]} #{Paint['copied to your clipboard',:green]}"
+        puts "--------------------------------"
         return true
       end
+
     else
-      pa %[No password found for #{key}!], :red
+      puts %[No password found for #{key}!], :red
       return false
     end
   end
   aliases_for :get, :entry, :copy, :password, :for, :[]
-  
+
   # Adds a password entry with a freshly generated random password
   def generate(
         key,
+        username  = nil,
         seconds   = @options[:seconds],
         length    = @options[:length],
         charpool  = @options[:charpool]
     )
-    get(key, seconds) if add(key, generator(length, charpool))
+    get(key, seconds) if add(key, username, generator(length, charpool))
   end
   alias_for :generate, :gen
-  
+
   # Updates a password entry with a freshly generated random password
   def update_generate(
         key,
@@ -151,7 +162,29 @@ class PWS
   alias :'update-generate' :update_generate
   alias :'update_gen'      :update_generate
   alias :'update-gen'      :update_generate
-  
+
+  def update_username(
+    key,
+    username = nil
+    )
+
+    if !@data[key]
+      pa %[There is no password stored for #{key}, so you cannot update it!], :red
+      return false
+    else
+      @data[key][:username] = username || ask_for_username(%[Please enter the new username for #{key}], :yellow)
+      if @data[key][:username].empty?
+        pa %[The username will be removed!], :red
+      else
+        pa %[The username for #{key} has been updated], :green
+      end
+
+      @data[key][:timestamp] = Time.now.to_i
+      write_safe
+    end
+  end
+  aliases_for :update_username, :add_username, :add_user, :set_user
+
   # Removes a specific password entry
   def remove(key)
     if @data.delete key
@@ -164,7 +197,7 @@ class PWS
     end
   end
   aliases_for :remove, :rm, :del, :delete
-  
+
   # Removes a specific password entry
   def rename(old_key, new_key)
     if !@data[old_key]
@@ -181,7 +214,7 @@ class PWS
     end
   end
   aliases_for :rename, :mv, :move
-  
+
   # Changes the master password
   def master(password = nil)
     unless @password = password
@@ -195,7 +228,7 @@ class PWS
     pa %[The master password has been changed], :green
     return true
   end
-  
+
   # Just writes the safe, useful for converting with --in and --out
   def resave
     write_safe
@@ -203,13 +236,13 @@ class PWS
     return true
   end
   alias_for :resave, :convert
-  
+
   # Prevents accidental displaying, e.g. in irb
   def to_s
     %[#<password safe>]
   end
   alias_for :to_s, :inspect
-  
+
   private
 
   def collect_options(options = {})
@@ -222,7 +255,7 @@ class PWS
     @options[:out]        ||= ENV['PWS_FORMAT']     || VERSION
     @options[:iterations] ||= ENV['PWS_ITERATIONS'] || 75_000
   end
-  
+
   # Checks if the file is accessible or create a new one
   # Tries to load and decrypt the password safe from the pwfile
   def read_safe(password = nil)
@@ -230,7 +263,7 @@ class PWS
       print %[Access password safe at #@filename | ]
       @password = password || ask_for_password(%[master password])
       encrypted_data = File.read(@filename)
-      
+
       @data = Format.read(
         encrypted_data,
         password: @password,
@@ -239,12 +272,12 @@ class PWS
       update_abbrevs!
     else
       create_safe(password)
-    end 
+    end
 
     pa %[ACCESS GRANTED], :green
   end
-  
-  
+
+
   # Tries to encrypt and save the password safe into the pwfile
   def write_safe
     encrypted_data = Format.write(
@@ -256,7 +289,7 @@ class PWS
     File.open(@filename, 'w'){ |f| f.write(encrypted_data) }
     update_abbrevs!
   end
-  
+
   def create_safe(password = nil)
     pa %[No password safe detected, creating one at #@filename], :blue, :bold
     unless @password = password
@@ -266,13 +299,24 @@ class PWS
         raise ArgumentError, %[The passwords don't match!]
       end
     end
-    
+
     FileUtils.mkdir_p(File.dirname(@filename))
     @data = {}
     write_safe
     File.chmod(0600, @filename)
   end
-  
+
+  # Prompts the user for a username
+  def ask_for_username(prompt = 'username', *colors)
+    print Paint["#{prompt}:".capitalize, *colors] + " "
+    #system 'stty -echo' if $stdin.tty?     # no more terminal output
+    username = ($stdin.gets||'').chop      # gets without $stdin would mistakenly read_safe from ARGV
+    #system 'stty echo'  if $stdin.tty?     # restore terminal output
+    #puts "\e[999D\e[K\e[1A" if $stdin.tty? # re-use prompt line in terminal
+
+    username
+  end
+
   # Prompts the user for a password
   def ask_for_password(prompt = 'new password', *colors)
     print Paint["#{prompt}:".capitalize, *colors] + " "
@@ -280,10 +324,10 @@ class PWS
     password = ($stdin.gets||'').chop      # gets without $stdin would mistakenly read_safe from ARGV
     system 'stty echo'  if $stdin.tty?     # restore terminal output
     puts "\e[999D\e[K\e[1A" if $stdin.tty? # re-use prompt line in terminal
-    
+
     password
   end
-  
+
   # Generate a random password, maybe put in its own class sometime
   def generator(length, charpool)
     charpool_size = charpool.size

--- a/lib/pws/format/1.1.rb
+++ b/lib/pws/format/1.1.rb
@@ -1,0 +1,211 @@
+# encoding: ascii
+
+require_relative '../format'
+require 'securerandom'
+require 'digest/hmac'
+require 'openssl'
+require 'pbkdf2'
+
+class PWS
+  module Format
+    # PWS file format for versions ~> 1.1.0
+    # see at bottom block for a short format description
+    module V1_1
+      TEMPLATE = 'a64 a16 N a64 a*'.freeze
+      DEFAULT_ITERATIONS =        75_000
+      MAX_ITERATIONS     =    10_000_000
+      MAX_ENTRY_LENGTH   = 4_294_967_295 # N
+
+      class << self
+        def write(application_data, options = {})
+          encrypt(marshal(application_data), options)
+        end
+
+        def encrypt(unencrypted_data, options = {})
+          raise ArgumentError, 'No password given' if \
+              !options[:password]
+
+          iterations = ( options[:iterations] || DEFAULT_ITERATIONS ).to_i
+          raise ArgumentError, 'Invalid iteration count given' if \
+              iterations > MAX_ITERATIONS || iterations < 2
+
+          salt = SecureRandom.random_bytes(64)
+          iv  = Encryptor.random_iv
+
+          encryption_key, hmac_key = kdf(
+            options[:password],
+            salt,
+            iterations,
+          ).unpack('a256 a256')
+
+          sha = hmac(hmac_key, salt, iv, iterations, unencrypted_data)
+
+          encrypted_data = Encryptor.encrypt(
+            unencrypted_data,
+            key: encryption_key,
+            iv:  iv,
+          )
+
+          [salt, iv, iterations, sha, encrypted_data].pack(TEMPLATE)
+        end
+
+        def marshal(application_data, options = {})
+          number_of_dummy_bytes = 100_000 + SecureRandom.random_number(1_000_000)
+          ordered_data = application_data.to_a
+
+          [
+            number_of_dummy_bytes,
+            application_data.size,
+            SecureRandom.random_bytes(number_of_dummy_bytes) +
+            array_to_data_string(ordered_data.map{ |_, e| e[:username].to_s }) +
+            array_to_data_string(ordered_data.map{ |_, e| e[:password].to_s }) +
+            array_to_data_string(ordered_data.map{ |k, _| k.to_s }) +
+            array_to_data_string(ordered_data.map{ |_, e| e[:timestamp].to_i }) +
+            SecureRandom.random_bytes(100_000 + SecureRandom.random_number(1_000_000))
+          ].pack('N N a*')
+        end
+
+        # - - -
+
+        def read(encrypted_data, options = {})
+          unmarshal(decrypt(encrypted_data, options))
+        end
+
+        def decrypt(saved_data, options = {})
+          raise ArgumentError, 'No password given' if \
+              !options[:password]
+          raise ArgumentError, 'No data given' if \
+              !saved_data || saved_data.empty?
+          salt, iv, iterations, sha, encrypted_data = saved_data.unpack(TEMPLATE)
+
+          raise NoAccess, 'Password file invalid' if \
+              salt.size != 64             ||
+              iterations > MAX_ITERATIONS ||
+              iv.size != 16               ||
+              sha.size != 64
+
+          encryption_key, hmac_key = kdf(
+            options[:password],
+            salt,
+            iterations,
+          ).unpack('a256 a256')
+
+          begin
+            unencrypted_data = Encryptor.decrypt(
+              encrypted_data,
+              key: encryption_key,
+              iv:  iv,
+            )
+          rescue OpenSSL::Cipher::CipherError
+            raise NoAccess, 'Could not decrypt'
+          end
+
+          raise NoAccess, 'Password file invalid' unless \
+              sha == hmac(hmac_key, salt, iv, iterations, unencrypted_data)
+
+          unencrypted_data
+        end
+
+        def unmarshal(saved_data, options = {})
+          number_of_dummy_bytes, data_size, raw_data = saved_data.unpack('N N a*')
+          i = number_of_dummy_bytes
+
+          usernames, passwords, names, timestamps = 4.times.map{
+            data_size.times.map{
+              next_element, i = get_next_data_string(raw_data, i)
+              next_element
+            }
+          }
+
+          Hash[
+            names.zip(
+              passwords.zip(usernames,timestamps).map{ |u,e,f|
+                { username: u.to_s, password: e.to_s, timestamp: f.to_i }
+              }
+            )
+          ]
+        end
+
+        # support
+
+        def hmac(key, *strings)
+          Digest::HMAC.new(key, Digest::SHA512).update(
+            strings.map(&:to_s).join
+          ).digest
+        end
+
+        def kdf_openssl(password, salt, iterations)
+          OpenSSL::PKCS5::pbkdf2_hmac(
+            password,
+            salt,
+            iterations,
+            512,
+            OpenSSL::Digest::SHA512.new,
+          )
+        end
+
+        def kdf_ruby(password, salt, iterations)
+          PBKDF2.new(
+            password: password,
+            salt: salt,
+            iterations: iterations,
+            key_length: 512,
+            hash_function: OpenSSL::Digest::SHA512,
+          ).bin_string
+        end
+
+        # see gh#7
+        begin
+          OpenSSL::PKCS5::pbkdf2_hmac("","",2,512,OpenSSL::Digest::SHA512.new)
+        rescue NotImplementedError
+          alias kdf kdf_ruby
+          warn "[pws slow] https://github.com/janlelis/pws#openssl-10"
+        else
+          alias kdf kdf_openssl
+        end
+
+        private
+
+        def array_to_data_string(array)
+          array.map{ |e|
+            e = e.to_s
+            s = e.bytesize
+            raise(ArgumentError, 'Entry too long') if s > MAX_ENTRY_LENGTH
+            [s, e].pack('N a*')
+          }.join
+        end
+
+        def get_next_data_string(string, pos)
+          res_length = string[pos..pos+4].unpack('N')[0]
+          new_pos = pos + 4 + res_length
+          res = string[pos+4...new_pos].unpack('a*')[0]
+
+          [res, new_pos]
+        end
+      end#self
+    end#V1_0
+  end
+end
+
+=begin ENCRYPTION FORMAT
+
+Bytes  Data            Description
+64     SALT            Randomly generated, used by kdf
+16     IV              Randomly generated, used by aes
+4      ITERATIONS      How often the password gets hashed by the kdf
+64     HMAC            On everything
+*      ENCRYPTED_DATA
+
+=end
+
+=begin MARSHAL FORMAT
+
+number of dummy bytes before real data
+dummy bytes
+usernames
+passwords
+names
+timestamps
+dummy bytes
+
+=end

--- a/lib/pws/runner.rb
+++ b/lib/pws/runner.rb
@@ -14,7 +14,7 @@ module PWS::Runner
       options   = {}
       arguments = []
       argv.unshift(nil) # easier parsing
-      
+
       argv.each_cons(2){ |prev_arg, arg|
         case arg
         when '-'
@@ -37,10 +37,10 @@ module PWS::Runner
           end
         end
       }
-      
+
       [action || :show, arguments, options]
     end
-    
+
     # makes the Ruby safe usable from the cli
     def run(action, arguments, options)
       case action
@@ -48,23 +48,23 @@ module PWS::Runner
         puts "pws #{PWS::VERSION} by " + Paint["J-_-L", :bold] + " <https://github.com/janlelis/pws>"
       when :help, :actions, :commands
         puts(<<HELP)
-  
+
   #{Paint["Usage", :underline]}
-  
+
   #{Paint['pws', :bold]} [-namespace] action [arguments] [--options]
-  
+
   #{Paint["Info", :underline]}
-  
+
   pws allows you to manage passwords in encryted password files (safes). It
   operates on the file specified in the environment variable PWS or on "~/.pws".
   Using a single dash, you can set a namespace that will be appended to the
   filename, e.g. `pws -work show` will operate on "~/.pws-work".
-  
+
   #{Paint["Available Actions", :underline]}
-  
+
   #{Paint['ls', :bold]} / list / show / status ( pattern = nil )
   Lists all available password entries. Optionally takes a regex filter.
-  
+
   #{Paint['get', :bold]} / entry / copy / password / for ( name, seconds = 10 )
   Copies the password for <name> to the clipboard. The second argument specifies,
   how long the password is kept in the clipboard (0 = no deletion).
@@ -72,68 +72,71 @@ module PWS::Runner
   #{Paint['add', :bold]} / set / store / create ( name, password = nil )
   Stores a new password entry. The second argument can be the password, but
   it's recommended to not pass it, but enter it interactively.
-  
+
   #{Paint['gen', :bold]} / generate ( name, seconds = 10, length = 64, char_pool )
   Generates a new password for <name> and then copies it to the clipboard, like
   get (the second argument is the time - it gets passed to get). The third
   argument sets the password length. The fourth argument allows you to pass a
   character pool that is used for generating the passwords.
-  
+
   #{Paint['update', :bold]} / update-add ( name, password = nil )
   Updates an existing password entry.
-  
+
   #{Paint['update-gen', :bold]} / update-generate( name, seconds = 10, length = 64, char_pool )
   Updates an existing password entry using the generate method.
-  
+
   #{Paint['rm', :bold]} / remove / del / delete ( name )
   Removes a password entry.
-  
+
   #{Paint['mv', :bold]} / move / rename ( old_name, new_name )
   Renames a password entry.
-  
+
+  #{Paint['set_user', :bold]} / update_username / add_username / add_user ( name, new_username )
+  Changes (or sets) the username associated with a password entry.
+
   #{Paint['master', :bold]} ( password = nil )
   Changes the master password.
-  
+
   #{Paint['resave', :bold]} / convert
   Just save the safe. Useful for converting the file format.
-  
+
   #{Paint['v', :bold]} / version
   Displays version and website.
-  
+
   #{Paint['help', :bold]} / actions / commands
   Displays this help.
 
   #{Paint["Available Options", :underline]}
-  
+
   #{Paint['--in', :bold]}
   Specifies the password file input format. Neccessary to convert 0.9 safes.
   Supported values: 0.9 1.0
-  
+
   #{Paint['--out', :bold]}
   Specifies the password file output format. Ignored for non-writing actions,
   e.g. get. Defaults to the current version.
   Supported values: 1.0
-  
+
   #{Paint['--filename', :bold]}
   Path to the password safe to use. Overrides usual path and any namespaces.
-  
+
   #{Paint['--cwd', :bold]}
   Use a .pws file in the current directory instead of the one specified in
   ENV['PWS'] or with --filename.
-  
+
   #{Paint['--iterations', :bold]}
   Sets the number of sha iterations used to transform your password into the
   encryption key (pbkdf2). A higher number takes longer to compute, but makes
   it harder for attacker to bruteforce your password.
-  
-  #{Paint['--seconds', :bold]}, #{Paint['--length', :bold]}, #{Paint['--charpool', :bold]} 
+
+  #{Paint['--seconds', :bold]}, #{Paint['--length', :bold]}, #{Paint['--charpool', :bold]}
   Preset options for specific actions.
-  
+
   #{Paint["ENV Variables", :underline]}
-  
+
   You can use environment variables to customize the default settings of pws.
   Except for PWS (info at top), the following variables can be used:
-  
+
   PWS_SECONDS
   PWS_LENGTH
   PWS_CHARPOOL
@@ -168,7 +171,7 @@ HELP
       pa "..canceled", :red
       exit(5)
     end
-    
+
     # exit status codes (not final, yet)
     # 0 Success
     # 2 Successfully run, but operation not successful

--- a/lib/pws/version.rb
+++ b/lib/pws/version.rb
@@ -1,3 +1,3 @@
 class PWS
-  VERSION = '1.0.5'
+  VERSION = '1.1'
 end


### PR DESCRIPTION
I created a new formatter that supports usernames in password entries. When creating an entry, the user is now prompted for a username and a password. The username is optional.
When calling 'get', the user sees the username in clear and the password is copied in the clipboard as usual.
This is particularly helpful if you have accounts where you can't use the same username (e.g. your email address) or - worse - when username and password are fixed by the system (had this experience personally with some institutional websites).
