### PR TITLE
Excluded chars option

### DIFF
--- a/features/generate.feature
+++ b/features/generate.feature
@@ -94,4 +94,11 @@ Feature: Generate
     And  the output should contain "The password for github has been copied to your clipboard"
     And  the clipboard should match ^a{64}$
 
-
+  Scenario: Generate a new password for "github", exclude the characters "ABC123" from the charpool
+    Given A safe exists with master password "my_master_password"
+    When I run `pws generate github 0 --exclude ABC123` interactively
+    And I type "my_master_password"
+    Then the output should contain "Master password:"
+    And the output should contain "The password for github has been added"
+    And  the output should contain "The password for github has been copied to your clipboard"
+    And  the clipboard should match [^ABC123]{64}

--- a/features/update-generate.feature
+++ b/features/update-generate.feature
@@ -116,3 +116,12 @@ Feature: Update
     And  the output should contain "The password for github has been updated"
     And  the output should contain "The password for github has been copied to your clipboard"
     And  the clipboard should match ^a{64}$
+
+  Scenario: Generate a new password for "github", exclude the characters "ABC123" from the charpool
+    Given A safe exists with master password "my_master_password" and a key "github" with password "old_password"
+    When I run `pws update-gen github 0 --exclude ABC123` interactively
+    And  I type "my_master_password"
+    Then the output should contain "Master password:"
+    And  the output should contain "The password for github has been updated"
+    And  the output should contain "The password for github has been copied to your clipboard"
+    And  the clipboard should match [^ABC123]{64}

--- a/lib/pws.rb
+++ b/lib/pws.rb
@@ -288,10 +288,7 @@ class PWS
   
   # Generate a random password, maybe put in its own class sometime
   def generator(length, charpool, exclude)
-    p "Before : #{charpool}"
-    p exclude
     charpool.tr!(exclude, '') if exclude
-    p "After : #{charpool}"
     charpool_size = charpool.size
     (1..length.to_i).map{
       charpool[SecureRandom.random_number(charpool_size)]

--- a/lib/pws.rb
+++ b/lib/pws.rb
@@ -133,9 +133,10 @@ class PWS
         key,
         seconds   = @options[:seconds],
         length    = @options[:length],
-        charpool  = @options[:charpool]
+        charpool  = @options[:charpool],
+        excluded  = @options[:exclude]
     )
-    get(key, seconds) if add(key, generator(length, charpool))
+    get(key, seconds) if add(key, generator(length, charpool, excluded))
   end
   alias_for :generate, :gen
   
@@ -144,9 +145,10 @@ class PWS
         key,
         seconds   = @options[:seconds],
         length    = @options[:length],
-        charpool  = @options[:charpool]
+        charpool  = @options[:charpool],
+        excluded  = @options[:exclude]
     )
-    get(key, seconds) if update(key, generator(length, charpool))
+    get(key, seconds) if update(key, generator(length, charpool, excluded))
   end
   alias :'update-generate' :update_generate
   alias :'update_gen'      :update_generate
@@ -285,7 +287,11 @@ class PWS
   end
   
   # Generate a random password, maybe put in its own class sometime
-  def generator(length, charpool)
+  def generator(length, charpool, exclude)
+    p "Before : #{charpool}"
+    p exclude
+    charpool.tr!(exclude, '') if exclude
+    p "After : #{charpool}"
     charpool_size = charpool.size
     (1..length.to_i).map{
       charpool[SecureRandom.random_number(charpool_size)]

--- a/lib/pws/runner.rb
+++ b/lib/pws/runner.rb
@@ -126,7 +126,7 @@ module PWS::Runner
   encryption key (pbkdf2). A higher number takes longer to compute, but makes
   it harder for attacker to bruteforce your password.
   
-  #{Paint['--seconds', :bold]}, #{Paint['--length', :bold]}, #{Paint['--charpool', :bold]} 
+  #{Paint['--seconds', :bold]}, #{Paint['--length', :bold]}, #{Paint['--charpool', :bold]}, #{Paint['--exclude', :bold]}
   Preset options for specific actions.
   
   #{Paint["ENV Variables", :underline]}


### PR DESCRIPTION
## Description:

Implementation of feature described in #21 

Allows a user to run `pws gen foo --exclude ABC123` and generate a password not including the specified characters.

## Unimplemented Behavior:
Support for an environment variable `PWS_EXCLUDE` is not included in this PR.

## Note on tests:
- This PR implements tests, however I am not able to discern the reason for the labels on other test cases (e.g.` @wait-11s` or `@slow-hack`) and so I did not implement them in this PR.  If there is a good reason that a label should be applied to the test cases I would be happy to add them.
- This is my first time writing Gherkin/Cucumber tests, so perhaps these particular cases merit extra scrutiny.
- I encountered an error upon a fresh clone of this repo which I described in #22.  AFAIK this error is unrelated to this PR.

